### PR TITLE
Update library to php7.4 and phpunit to 9.5

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,7 @@
 build:
     environment:
         php:
-            version: 7.1
+            version: 7.4
     tests:
         override:
             -

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ cache:
     - $HOME/.composer/cache
 matrix:
     include:
-        - php: 7.0
+        - php: 7.4
           env: deps=low
-        - php: 7.0
-        - php: 7.1
+        - php: 8.0
         - php: nightly
     fast_finish: true
     allow_failures:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Lesnykh Ilia
+Copyright (c) 2016-2021 Lesnykh Ilia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ About
 
 Bitmask is a simple PHP implementation of bitwise operations for creating masks.
 Can be used for some flags implementation.
-Currently supported PHP version: >= 7.0
+Currently supported PHP version: >= 7.4
 
 Installation
 ---
@@ -35,12 +35,14 @@ Read: no
 Update: no
 Delete: no
 –––––––––––––––––––––––––––––––––––
+
 Check user for all access levels:
 Create: no
 Read: yes
 Update: no
 Delete: no
 –––––––––––––––––––––––––––––––––––
+
 ```
 
 Tests

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
     }
   },
   "require": {
-    "php-64bit": ">=7.0"
+    "php-64bit": ">=7.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.2"
+    "phpunit/phpunit": "~9"
   }
 }

--- a/example/example.php
+++ b/example/example.php
@@ -1,17 +1,19 @@
 <?php
 
+declare(strict_types=1);
+
 require_once realpath(__DIR__ . '/../vendor/autoload.php');
 
-/*
+/**
  * For example, we have some blog with users stored in some storage.
  * The main entity for blog – news.
  * Users should have the ACL for creating, reading, updating and deleting news.
  */
 
-define('ACCESS_CREATE', 1);
-define('ACCESS_READ', 2);
-define('ACCESS_UPDATE', 3);
-define('ACCESS_DELETE', 4);
+define('ACCESS_CREATE', 0);
+define('ACCESS_READ', 1);
+define('ACCESS_UPDATE', 2);
+define('ACCESS_DELETE', 3);
 // etc, up to 63
 
 // some users from storage
@@ -20,7 +22,7 @@ $user = [
 ];
 
 // create a Bitmask object, passing user bitmask from storage
-$Bitmask = \Aliance\Bitmask\Bitmask::create($user['access_level']);
+$Bitmask = new \Aliance\Bitmask\Bitmask($user['access_level']);
 
 checkRights($Bitmask);
 
@@ -36,5 +38,5 @@ function checkRights(\Aliance\Bitmask\Bitmask $Bitmask)
     echo 'Read: ', $Bitmask->issetBit(ACCESS_READ) ? 'yes' : 'no', PHP_EOL;
     echo 'Update: ', $Bitmask->issetBit(ACCESS_UPDATE) ? 'yes' : 'no', PHP_EOL;
     echo 'Delete: ', $Bitmask->issetBit(ACCESS_DELETE) ? 'yes' : 'no', PHP_EOL;
-    echo str_repeat('–', 35), PHP_EOL;
+    echo str_repeat('–', 35), PHP_EOL . PHP_EOL;
 }

--- a/example/example.php
+++ b/example/example.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 require_once realpath(__DIR__ . '/../vendor/autoload.php');
 
-/**
+/*
  * For example, we have some blog with users stored in some storage.
  * The main entity for blog – news.
  * Users should have the ACL for creating, reading, updating and deleting news.
@@ -38,5 +38,5 @@ function checkRights(\Aliance\Bitmask\Bitmask $Bitmask)
     echo 'Read: ', $Bitmask->issetBit(ACCESS_READ) ? 'yes' : 'no', PHP_EOL;
     echo 'Update: ', $Bitmask->issetBit(ACCESS_UPDATE) ? 'yes' : 'no', PHP_EOL;
     echo 'Delete: ', $Bitmask->issetBit(ACCESS_DELETE) ? 'yes' : 'no', PHP_EOL;
-    echo str_repeat('–', 35), PHP_EOL . PHP_EOL;
+    echo str_repeat('–', 35), PHP_EOL, PHP_EOL;
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,13 @@
-<phpunit
-        bootstrap="vendor/autoload.php"
-        colors="true"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        verbose="true"
->
-    <testsuites>
-        <testsuite name="general">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="general">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Bitmask.php
+++ b/src/Bitmask.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Aliance\Bitmask;
 
 /**
@@ -7,122 +10,71 @@ namespace Aliance\Bitmask;
  */
 class Bitmask
 {
-    /**
-     * @var int
-     */
-    const MAX_BIT = 63;
+    private const MAX_BIT = 63;
 
-    /**
-     * @var int
-     */
-    private $mask;
+    private int $mask;
 
-    /**
-     * @param int $mask
-     */
-    public function __construct($mask = 0)
+    public function __construct(int $mask = 0)
     {
         $this->setMask($mask);
     }
 
-    /**
-     * @param int $mask
-     * @return $this
-     */
-    public static function create($mask = 0)
-    {
-        return new self($mask);
-    }
-
-    /**
-     * @param int $bit
-     * @return $this
-     */
-    public function setBit($bit)
+    public function setBit(int $bit): self
     {
         return $this->addMask(1 << $this->checkBit($bit));
     }
 
-    /**
-     * @param int $mask
-     * @return $this
-     */
-    public function addMask($mask)
+    public function addMask(int $mask): self
     {
         $this->mask |= $mask;
         return $this;
     }
 
-    /**
-     * @param int $bit
-     * @return int
-     * @throws \InvalidArgumentException
-     */
-    private function checkBit($bit)
-    {
-        if ($bit > self::MAX_BIT) {
-            throw new \InvalidArgumentException(sprintf(
-                'Bit number %d is greater than possible limit %d.',
-                $bit,
-                self::MAX_BIT
-            ));
-        }
-        return $bit;
-    }
-
-    /**
-     * @param int $bit
-     * @return $this
-     */
-    public function unsetBit($bit)
+    public function unsetBit(int $bit): self
     {
         return $this->deleteMask(1 << $this->checkBit($bit));
     }
 
-    /**
-     * @param int $mask
-     * @return $this
-     */
-    public function deleteMask($mask)
+    public function deleteMask(int $mask): self
     {
         $this->mask &= ~$mask;
         return $this;
     }
 
-    /**
-     * @param int $bit
-     * @return bool
-     */
-    public function issetBit($bit)
+    public function issetBit(int $bit): bool
     {
-        return (bool)($this->getMask() & (1 << $this->checkBit($bit)));
+        return (bool) ($this->getMask() & (1 << $this->checkBit($bit)));
     }
 
-    /**
-     * @return int
-     */
-    public function getMask()
+    public function getMask(): int
     {
         return $this->mask;
     }
 
-    /**
-     * @param int $mask
-     * @return $this
-     */
-    public function setMask($mask)
+    public function setMask(int $mask): self
     {
-        $this->mask = (int)$mask;
+        $this->mask = $mask;
         return $this;
     }
 
     /**
      * Return set bits count.
      * Actually, counts the number of 1 in binary representation of the decimal mask integer.
-     * @return int
      */
-    public function getSetBitsCount()
+    public function getSetBitsCount(): int
     {
         return substr_count(decbin($this->mask), '1');
+    }
+
+    private function checkBit(int $bit): int
+    {
+        if ($bit > self::MAX_BIT || $bit < 0) {
+            throw new \InvalidArgumentException(sprintf(
+                'Bit number %d is out of range [0..%d].',
+                $bit,
+                self::MAX_BIT
+            ));
+        }
+        return $bit;
     }
 }

--- a/tests/BitmaskTest.php
+++ b/tests/BitmaskTest.php
@@ -14,11 +14,6 @@ class BitmaskTest extends TestCase
 {
     private Bitmask $bitmask;
 
-    protected function setUp(): void
-    {
-        $this->bitmask = new Bitmask();
-    }
-
     public function testBitmaskCreation(): void
     {
         $this->assertInstanceOf(Bitmask::class, new Bitmask());
@@ -122,11 +117,19 @@ class BitmaskTest extends TestCase
                 0, // no bits will be set
             ],
             [
-                [1, 3, 6],
+                [
+                    1,
+                    3,
+                    6,
+                ],
                 74, // 2^1 + 2^3 + 2^6 = 2 + 8 + 64
             ],
             [
-                [2, 10, 30,],
+                [
+                    2,
+                    10,
+                    30,
+                ],
                 1073742852, // 2^2 + 2^10 + 2^30 = 4 + 1024 + 1073741824
             ],
             [
@@ -134,5 +137,10 @@ class BitmaskTest extends TestCase
                 -1, // in php int64 always signed :(
             ],
         ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->bitmask = new Bitmask();
     }
 }

--- a/tests/BitmaskTest.php
+++ b/tests/BitmaskTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Aliance\Bitmask\Tests;
 
 use Aliance\Bitmask\Bitmask;
@@ -10,112 +12,109 @@ use PHPUnit\Framework\TestCase;
  */
 class BitmaskTest extends TestCase
 {
-    /**
-     * @var Bitmask
-     */
-    private $Bitmask;
+    private Bitmask $bitmask;
 
-    public function testBitmaskCreation()
+    protected function setUp(): void
     {
-        $this->assertInstanceOf(Bitmask::class, Bitmask::create());
+        $this->bitmask = new Bitmask();
     }
 
-    public function testEmptyBitmask()
+    public function testBitmaskCreation(): void
     {
-        $this->assertEquals(0, $this->Bitmask->getSetBitsCount());
-        $this->assertEquals(0, $this->Bitmask->getMask());
-        $this->assertFalse($this->Bitmask->issetBit(1));
+        $this->assertInstanceOf(Bitmask::class, new Bitmask());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testThatTooBigBitCauseAnException()
+    public function testEmptyBitmask(): void
     {
-        $this->Bitmask->setBit(Bitmask::MAX_BIT + 1);
+        $this->assertEquals(0, $this->bitmask->getSetBitsCount());
+        $this->assertEquals(0, $this->bitmask->getMask());
+        $this->assertFalse($this->bitmask->issetBit(1));
     }
 
-    public function testMaskSetting()
+    public function testThatTooBigBitCauseAnException(): void
     {
-        $this->assertEquals(0, $this->Bitmask->getMask());
-        $this->Bitmask->setMask(1024);
-        $this->assertEquals(1024, $this->Bitmask->getMask());
+        $this->expectException(\InvalidArgumentException::class);
+        $this->bitmask->setBit(64);
     }
 
-    public function testMaskAdding()
+    public function testMaskSetting(): void
     {
-        $this->assertEquals(0, $this->Bitmask->getMask());
-
-        // adding 10 bit
-        $this->Bitmask->addMask(1024);
-        $this->assertEquals(1024, $this->Bitmask->getMask());
-
-        // adding 3 bit
-        $this->Bitmask->addMask(8);
-        $this->assertEquals(1032, $this->Bitmask->getMask());
+        $this->assertEquals(0, $this->bitmask->getMask());
+        $this->bitmask->setMask(1024);
+        $this->assertEquals(1024, $this->bitmask->getMask());
     }
 
-    public function testMaskDeleting()
+    public function testMaskAdding(): void
     {
-        $this->assertEquals(0, $this->Bitmask->getMask());
+        $this->assertEquals(0, $this->bitmask->getMask());
 
-        // adding 3 & 10 bits
-        $this->Bitmask->setMask(1032);
-        $this->assertEquals(1032, $this->Bitmask->getMask());
+        // adding 10th bit
+        $this->bitmask->addMask(1024);
+        $this->assertEquals(1024, $this->bitmask->getMask());
 
-        // deleting 10 bit
-        $this->Bitmask->deleteMask(1024);
-        $this->assertEquals(8, $this->Bitmask->getMask());
+        // adding 3rd bit
+        $this->bitmask->addMask(8);
+        $this->assertEquals(1032, $this->bitmask->getMask());
     }
 
-    public function testBits()
+    public function testMaskDeleting(): void
     {
-        $this->assertFalse($this->Bitmask->issetBit(3));
-        $this->assertFalse($this->Bitmask->issetBit(5));
-        $this->assertFalse($this->Bitmask->issetBit(12));
-        $this->assertFalse($this->Bitmask->issetBit(63));
+        $this->assertEquals(0, $this->bitmask->getMask());
 
-        $this->Bitmask->setBit(3);
-        $this->Bitmask->setBit(12);
-        $this->Bitmask->setBit(63);
+        // adding 3rd & 10th bits
+        $this->bitmask->setMask(1032);
+        $this->assertEquals(1032, $this->bitmask->getMask());
 
-        $this->assertTrue($this->Bitmask->issetBit(3));
-        $this->assertFalse($this->Bitmask->issetBit(5));
-        $this->assertTrue($this->Bitmask->issetBit(12));
-        $this->assertTrue($this->Bitmask->issetBit(63));
+        // deleting 10th bit
+        $this->bitmask->deleteMask(1024);
+        $this->assertEquals(8, $this->bitmask->getMask());
+    }
 
-        $this->Bitmask->unsetBit(12);
-        $this->Bitmask->unsetBit(63);
+    public function testBits(): void
+    {
+        $this->assertFalse($this->bitmask->issetBit(3));
+        $this->assertFalse($this->bitmask->issetBit(5));
+        $this->assertFalse($this->bitmask->issetBit(12));
+        $this->assertFalse($this->bitmask->issetBit(63));
 
-        $this->assertTrue($this->Bitmask->issetBit(3));
-        $this->assertFalse($this->Bitmask->issetBit(5));
-        $this->assertFalse($this->Bitmask->issetBit(12));
-        $this->assertFalse($this->Bitmask->issetBit(63));
+        $this->bitmask->setBit(3);
+        $this->bitmask->setBit(12);
+        $this->bitmask->setBit(63);
+
+        $this->assertTrue($this->bitmask->issetBit(3));
+        $this->assertFalse($this->bitmask->issetBit(5));
+        $this->assertTrue($this->bitmask->issetBit(12));
+        $this->assertTrue($this->bitmask->issetBit(63));
+
+        $this->bitmask->unsetBit(12);
+        $this->bitmask->unsetBit(63);
+
+        $this->assertTrue($this->bitmask->issetBit(3));
+        $this->assertFalse($this->bitmask->issetBit(5));
+        $this->assertFalse($this->bitmask->issetBit(12));
+        $this->assertFalse($this->bitmask->issetBit(63));
     }
 
     /**
      * @dataProvider getBitsWithMaskPairs
      * @param int[] $bits
-     * @param int   $expectedMask
+     * @param int $expectedMask
      */
-    public function testGeneralUsage($bits, $expectedMask)
+    public function testGeneralUsage(array $bits, int $expectedMask): void
     {
         foreach ($bits as $bit) {
-            $this->Bitmask->setBit($bit);
+            $this->bitmask->setBit($bit);
         }
 
-        $this->assertCount($this->Bitmask->getSetBitsCount(), $bits);
-        $this->assertEquals($expectedMask, $this->Bitmask->getMask());
+        $this->assertCount($this->bitmask->getSetBitsCount(), $bits);
+        $this->assertEquals($expectedMask, $this->bitmask->getMask());
 
         foreach ($bits as $bit) {
-            $this->assertTrue($this->Bitmask->issetBit($bit));
+            $this->assertTrue($this->bitmask->issetBit($bit));
         }
     }
 
-    /**
-     * @return array
-     */
-    public function getBitsWithMaskPairs()
+    public function getBitsWithMaskPairs(): array
     {
         return [
             [
@@ -123,33 +122,17 @@ class BitmaskTest extends TestCase
                 0, // no bits will be set
             ],
             [
-                [
-                    1,
-                    3,
-                    6,
-                ],
+                [1, 3, 6],
                 74, // 2^1 + 2^3 + 2^6 = 2 + 8 + 64
             ],
             [
-                [
-                    2,
-                    10,
-                    30,
-                ],
+                [2, 10, 30,],
                 1073742852, // 2^2 + 2^10 + 2^30 = 4 + 1024 + 1073741824
             ],
             [
-                range(0, Bitmask::MAX_BIT),
+                range(0, 63),
                 -1, // in php int64 always signed :(
             ],
         ];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp()
-    {
-        $this->Bitmask = new Bitmask();
     }
 }


### PR DESCRIPTION
What's new:

- support php7.4+
- strict types
- type hinting in methods and class properties
- update phpunit to 9.5
- update for example file